### PR TITLE
Rename smoky paprika stew to Transylvania Stew

### DIFF
--- a/doc/stews/index.rst
+++ b/doc/stews/index.rst
@@ -5,7 +5,7 @@ Stews
     :maxdepth: 1
 
     jewish-brisket
-    smoky-paprika-vegetable-stew
+    transylvania-stew
     stove-top-brisket
     three-can-chili
     vegetarian-chili

--- a/doc/stews/transylvania-stew.rst
+++ b/doc/stews/transylvania-stew.rst
@@ -1,5 +1,9 @@
-Smoky Paprika Vegetable Stew with Impossible Hot Dogs
-=====================================================
+Transylvania Stew
+=================
+
+This stew is named after the Transylvania region, inspired by Romanian and
+Hungarian cooking traditions. The generous amount of garlic (a whole head!)
+also evokes the vampire-warding folklore of the region.
 
 Fills a 4-quart slow cooker, makes approximately 6-8 servings.
 Serve over rice.


### PR DESCRIPTION
Renamed the recipe to better reflect its inspiration from Romanian and
Hungarian cooking traditions. Added explanation about the name, highlighting
the generous use of garlic (a whole head) which also evokes the vampire-warding
folklore of the Transylvania region.