### PR TITLE
Add TVP and porcini ragù recipe

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -34,3 +34,4 @@ Moshe'z Recipes
     breakfast-burrito
     veggie-dog-pinto-bean-bake
     mujadara-hamra
+    tvp-porcini-ragu

--- a/doc/tvp-porcini-ragu.rst
+++ b/doc/tvp-porcini-ragu.rst
@@ -22,17 +22,17 @@ Ingredients
 * 15 grams white miso
 * 2 grams unsweetened cocoa powder
 * 1 bay leaf
-* 0.3 teaspoons red pepper flakes
-* 100 milliliters unsweetened soy milk
+* 0.5 grams red pepper flakes
+* 100 grams unsweetened soy milk
 * 10 grams balsamic vinegar
 * 8 grams nutritional yeast
-* 1 teaspoon salt
-* 0.5 teaspoons black pepper
+* 6 grams salt
+* 1 gram black pepper
 
 Method
 ~~~~~~
 
-#. Soak the porcini: Heat 600ml of water to 65°C. Pour it over the
+#. Soak the porcini: Heat 600 grams of water to 65°C. Pour it over the
    dried porcini mushrooms, cover, and leave to steep. Not boiling
    water — the enzyme that generates guanylate during rehydration
    works in this temperature window and boiling water destroys it on
@@ -40,7 +40,7 @@ Method
 #. Prep the vegetables: Finely dice the onion, carrot, and fennel
    bulb. Mince the garlic cloves.
 #. Rehydrate the TVP: Lift the porcini out, leaving the grit behind,
-   and chop them. Strain the liquid. Pour 280ml of it over the TVP
+   and chop them. Strain the liquid. Pour 280 grams of it over the TVP
    granules and let it absorb completely — nothing to drain, nothing
    thrown away. Reserve the remaining liquid for the deglaze.
 #. Brown the TVP: Heat half the olive oil over medium-high and fry the
@@ -71,7 +71,8 @@ Notes
 ~~~~~
 
 The porcini liquid is the whole umami budget of this sauce and none of
-it gets discarded: 280ml goes into the TVP, the rest deglazes the pan.
+it gets discarded: 280 grams go into the TVP, the rest deglazes the
+pan.
 Reduce further than you would a normal ragù — you want it thick enough
 to coat a small pour of pasta rather than pool around it. It's better
 on day two, and it freezes well in portions.

--- a/doc/tvp-porcini-ragu.rst
+++ b/doc/tvp-porcini-ragu.rst
@@ -1,0 +1,77 @@
+TVP and Porcini Ragù
+--------------------
+
+Shelf-stable TVP ragù. Dried porcini carry the umami; no fresh
+mushrooms, no wine, no celery.
+
+Ingredients
+~~~~~~~~~~~
+
+* 30 grams dried porcini mushrooms
+* 110 grams TVP granules (dry)
+* 150 grams onion
+* 70 grams carrot
+* 100 grams fennel bulb
+* 3 garlic cloves
+* 40 grams olive oil
+* 2 grams fennel seeds
+* 60 grams tomato paste
+* 12 grams red wine vinegar
+* 800 grams crushed tomatoes
+* 15 grams soy sauce
+* 15 grams white miso
+* 2 grams unsweetened cocoa powder
+* 1 bay leaf
+* 0.3 teaspoons red pepper flakes
+* 100 milliliters unsweetened soy milk
+* 10 grams balsamic vinegar
+* 8 grams nutritional yeast
+* 1 teaspoon salt
+* 0.5 teaspoons black pepper
+
+Method
+~~~~~~
+
+#. Soak the porcini: Heat 600ml of water to 65°C. Pour it over the
+   dried porcini mushrooms, cover, and leave to steep. Not boiling
+   water — the enzyme that generates guanylate during rehydration
+   works in this temperature window and boiling water destroys it on
+   contact.
+#. Prep the vegetables: Finely dice the onion, carrot, and fennel
+   bulb. Mince the garlic cloves.
+#. Rehydrate the TVP: Lift the porcini out, leaving the grit behind,
+   and chop them. Strain the liquid. Pour 280ml of it over the TVP
+   granules and let it absorb completely — nothing to drain, nothing
+   thrown away. Reserve the remaining liquid for the deglaze.
+#. Brown the TVP: Heat half the olive oil over medium-high and fry the
+   hydrated TVP until the edges crisp and it takes real color. Remove
+   and set aside. This is the only browning the sauce gets, so take it
+   further than feels necessary.
+#. Build the soffritto: Add the rest of the olive oil, holding back a
+   small drizzle for the finish, then the diced onion, carrot, and
+   fennel bulb. Cook until soft and lightly colored. Stir in the
+   garlic and fennel seeds for the last minute.
+#. Caramelize the paste: Push the vegetables to the side and add the
+   tomato paste. Fry until it darkens a shade, which concentrates its
+   glutamate and cooks off the raw-tomato edge.
+#. Deglaze: Pour in the reserved porcini liquid and the red wine
+   vinegar. Scrape up the fond and reduce by half. The vinegar goes in
+   here rather than later, so the simmer has time to round off its
+   sharpness.
+#. Simmer: Add the crushed tomatoes, the chopped porcini, the browned
+   TVP, the soy sauce, white miso, cocoa powder, bay leaf, and red
+   pepper flakes. Simmer uncovered, stirring now and then, until thick
+   and glossy. The TVP drinks sauce the entire time.
+#. Finish: Stir in the soy milk and reduce to a clinging consistency.
+   Off the heat, add the balsamic vinegar — late, so its aromatics
+   survive — then the reserved raw olive oil for gloss. Season with
+   the salt, black pepper, and nutritional yeast.
+
+Notes
+~~~~~
+
+The porcini liquid is the whole umami budget of this sauce and none of
+it gets discarded: 280ml goes into the TVP, the rest deglazes the pan.
+Reduce further than you would a normal ragù — you want it thick enough
+to coat a small pour of pasta rather than pool around it. It's better
+on day two, and it freezes well in portions.


### PR DESCRIPTION
Adds a new recipe: TVP and porcini ragù — a shelf-stable ragù where dried porcini carry the umami (no fresh mushrooms, no wine, no celery).

- New `doc/tvp-porcini-ragu.rst` following the standard recipe format (Ingredients, Method, Notes)
- Added to the toctree in `doc/index.rst`
- All quantities are in grams, including the former volumetric measures (teaspoons, milliliters)
- Verified with `nox -s docs` (`sphinx-build -W` passes with no warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VGKjdvYPHx69hL6WN4zpfZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGKjdvYPHx69hL6WN4zpfZ)_