### PR TITLE
Add hard-boiled eggs recipe tuned for induction temperature mode

### DIFF
--- a/doc/hard-boiled-eggs.rst
+++ b/doc/hard-boiled-eggs.rst
@@ -1,0 +1,63 @@
+Hard-Boiled Eggs
+================
+
+Fully hard yolks that are still tender and bright yellow, with no gray-green
+ring and no rubbery whites. The instructions are written for an induction
+stove whose temperature mode regulates the temperature of the pan bottom
+(not the water).
+
+Ingredients
+-----------
+
+* Up to 8 Large eggs, straight from the fridge
+* Water, enough to cover the eggs by about 1 inch
+* Ice, for an ice bath
+
+Preparation
+-----------
+
+1. Fill a pot with the water, without the eggs, and bring it to a boil:
+   set the temperature gauge to 240°F (115°C), or just use maximum power.
+2. Prepare a bowl of ice water.
+3. When the water boils, lower the eggs in gently with a slotted spoon and
+   start a 12 minute timer.
+4. Set the temperature gauge to 225°F (107°C) to hold a gentle boil for the
+   whole 12 minutes. The water should show steady, lazy streams of bubbles,
+   not a rolling boil.
+5. When the timer goes off, immediately move the eggs to the ice water and
+   leave them for 15 minutes.
+6. To peel, tap each egg all over to crackle the shell, start peeling from
+   the wide end (where the air pocket is), and work under cold running
+   water.
+
+Notes
+-----
+
+* **Why start the eggs in already-boiling water:** dropping eggs into
+  boiling water sets the outer white quickly so it does not fuse to the
+  shell membrane. This is the single biggest factor in easy peeling —
+  bigger than vinegar, salt, or egg age.
+* **Why 225°F on the gauge:** the thermostat holds the *pan bottom* at the
+  set temperature, but the water itself can never go above its boiling
+  point of 212°F (100°C) — the extra heat only goes into making steam. So a
+  setting a bit above 212°F produces a steady, self-limiting gentle boil
+  that cannot escalate into a violent boil that cracks the eggs. Setting
+  exactly 212°F usually stalls just *below* a boil: once the pan bottom and
+  the water are at the same temperature, almost no heat flows into the
+  water.
+* **Calibrate once for your stove:** sensors under the glass vary between
+  units. The first time, find the lowest setting that keeps a few steady
+  streams of bubbles rising — typically between 220°F and 230°F (105–110°C)
+  — and use that number from then on. This is what makes the recipe
+  repeatable: same setting, same eggs, same time, same result.
+* **Timing:** 12 minutes at a gentle boil gives a fully set, hard yolk for
+  large refrigerated eggs. For a slightly moist center, use 10–11 minutes.
+  Much past 14 minutes, iron and sulfur in the egg react and the yolk
+  develops a gray-green ring and a chalky texture.
+* **The ice bath is not optional:** it stops carryover cooking (which is
+  what pushes a just-right yolk into green-ring territory) and helps the
+  shell separate from the membrane.
+* **Altitude:** water boils below 212°F at altitude, so eggs cook slower;
+  add about 1 minute per 1000 feet above 3000 feet.
+* **Storage:** unpeeled hard-boiled eggs keep up to a week in the fridge in
+  an airtight container.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -36,3 +36,4 @@ Moshe'z Recipes
     mujadara-hamra
     tvp-porcini-ragu
     pea-protein-tahini-chocolate-pudding
+    hard-boiled-eggs


### PR DESCRIPTION
Adds a dedicated hard-boiled eggs recipe (`doc/hard-boiled-eggs.rst`) and links it from the index. Previously hard-boiled eggs only appeared as an ingredient in the tahini and Israeli salads.

The recipe is synthesized from several sources (Allrecipes' "Perfect Hard-Boiled Eggs", Kenji López-Alt's method, and extension-service food science on green-ring formation), targeting hard-but-not-overdone yolks:

- Start eggs in already-boiling water for easy peeling
- 12 minutes at a gentle boil for large fridge-cold eggs (10–11 for a slightly moist center; past ~14 risks the gray-green ferrous sulfide ring)
- Mandatory 15-minute ice bath to stop carryover cooking

Instructions are written for an induction stove whose temperature mode regulates the pan-bottom temperature: bring to a boil at 240°F, hold the gentle boil at 225°F. The Notes section explains why a set point slightly above 212°F gives a steady, self-limiting gentle boil (water can't exceed its boiling point) while exactly 212°F stalls below a boil, and includes a one-time calibration step, altitude adjustment, and storage guidance.

Verified locally with `nox -s docs` (build succeeded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018YuMLoPfLxFhNAgEYd7NSU

---
_Generated by [Claude Code](https://claude.ai/code/session_018YuMLoPfLxFhNAgEYd7NSU)_